### PR TITLE
The Render issue was resolved by setting mongoose.set('strictQuery', …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import session from 'express-session';
-
 import mongoose from 'mongoose';
 import setupSwagger from './config/swagger.js';
 import { initializePassport } from './middlewares/auth.js'; // Import the initializePassport function
@@ -19,10 +18,17 @@ const app = express();
 
 // Middleware
 app.use(express.json());
-app.use(session({ secret: process.env.SESSION_SECRET || 'default_secret', resave: false, saveUninitialized: true }));
+app.use(session({ 
+    secret: process.env.SESSION_SECRET || 'default_secret', 
+    resave: false, 
+    saveUninitialized: true 
+}));
 
 //Initialize Passport before using routes
 initializePassport(app);
+
+// Fix Mongoose Warning
+mongoose.set('strictQuery', false);
 
 // Database Connection
 mongoose.connect(process.env.MONGODB_URI, {


### PR DESCRIPTION
…false); to prevent a Mongoose deprecation warning. No changes were made to session handling.

The index.js file was updated to include the line mongoose.set('strictQuery', false); before establishing the connection to the MongoDB database. This prevents the Mongoose warning about the strictQuery option which will be switched to false by default in future versions. The session handling warning about MemoryStore persists but is not addressed at this time.